### PR TITLE
Fix dropdown hidden behind well

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -580,7 +580,7 @@ label[for="timezone-other"],
 
 /* Override FAB table views where table width extends beyond parent containers */
 .panel-body .panel-group + div {
-  overflow-x: auto;
+  overflow-x: visible;
 }
 
 .task-instance-modal-column {


### PR DESCRIPTION
The dropdown was getting cutoff when there were no records so the height was to short. Setting to visible from auto fixes.

![image](https://github.com/user-attachments/assets/9d68563f-1a3d-46e9-abdd-35d8a5f8803d)

![image](https://github.com/user-attachments/assets/397a2db3-8226-443a-97ae-d185de96487c)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue where the dropdown menu was hidden behind other elements by adjusting the CSS overflow property to ensure it is fully visible.

Bug Fixes:
- Fix dropdown menu being cut off by changing the overflow property from 'auto' to 'visible' in the CSS, ensuring it is fully displayed even when there are no records.

<!-- Generated by sourcery-ai[bot]: end summary -->